### PR TITLE
Remote server in [Stopped] state after Eclipse restart (issue TOOLS-2736)

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver.remote/src/org/wso2/developerstudio/eclipse/carbonserver/remote/internal/CarbonPingThread.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver.remote/src/org/wso2/developerstudio/eclipse/carbonserver/remote/internal/CarbonPingThread.java
@@ -46,6 +46,41 @@ public class CarbonPingThread implements Runnable {
 	}
 
 	public void startPing() {
+		// Create empty HostnameVerifier
+		try {
+			SSLContext sc = SSLContext.getInstance("SSL");
+			HostnameVerifier hv = new HostnameVerifier() {
+				public boolean verify(String arg0, SSLSession arg1) {
+					return true;
+				}
+			};
+			TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+
+				@Override
+				public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType)
+					throws CertificateException {
+				}
+
+				@Override
+				public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType)
+					throws CertificateException {
+				}
+
+				@Override
+				public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+					return null;
+				}
+			} };
+			sc.init(null, trustAllCerts, new java.security.SecureRandom());
+			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+			HttpsURLConnection.setDefaultHostnameVerifier(hv);
+
+		} catch (KeyManagementException e) {
+
+		} catch (NoSuchAlgorithmException e) {
+
+		}
+		
 		Thread t = new Thread(this);
 		t.setDaemon(true);
 		t.start();

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver.remote/src/org/wso2/developerstudio/eclipse/carbonserver/remote/internal/CarbonPingThread.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver.remote/src/org/wso2/developerstudio/eclipse/carbonserver/remote/internal/CarbonPingThread.java
@@ -20,10 +20,16 @@ import java.io.FileNotFoundException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-
-import org.eclipse.wst.server.core.IServer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 public class CarbonPingThread implements Runnable {
 	private static final int PING_DELAY = 2000;


### PR DESCRIPTION
Hi,
This pull request addresses issue TOOLS-2736 in OxygenTank
I believe it is SSL issue, so I added empty hostname verifier on SSL context when starting the tread.

Steps to reproduce the issue:
1) Install Eclipse (eclipse-jee-neon-2 in my case)
2) Install all plugins from http://product-dist.wso2.com/p2/developer-studio-kernel/4.1.0/esb-tools/releases/5.0.0/
3) add remote server on localhost (ESB 5.0.0 in my case)
4) deploy CAR file (with esb proxy)
5) everything ok so far, but restart the Eclipse
=> remote server is starting for a while, but eventually is in [Stopped] state

Steps to solve the issue:
1) compile from this fork
2) Install Remote Carbon plugin from jar wso2-developer-studio-tooling-platform-p2-4.1.0-201702162155.zip
3) Restart the Eclipse
=> Remote Carbon Servier is in [Started] state

Regards,
David