### PR TITLE
Hide the Connect to WSO2 App Cloud checkbox in the login dialog

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.registry.manager.remote/src/org/wso2/developerstudio/eclipse/registry/manager/remote/dialog/RegistryInfoDialog.java
+++ b/plugins/org.wso2.developerstudio.eclipse.registry.manager.remote/src/org/wso2/developerstudio/eclipse/registry/manager/remote/dialog/RegistryInfoDialog.java
@@ -115,7 +115,7 @@ public class RegistryInfoDialog extends Dialog {
 		gd = new GridData(GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_FILL);
 		container.setLayoutData(gd);
 		Label chkBoxLabel = new Label(container, SWT.NONE);
-		chkBoxLabel.setText("Connect to WSO2 App Cloud");
+//		chkBoxLabel.setText("Connect to WSO2 App Cloud");
 		gd = new GridData();
 		chkBoxLabel.setLayoutData(gd);
 
@@ -123,6 +123,8 @@ public class RegistryInfoDialog extends Dialog {
 		gd = new GridData(GridData.FILL_BOTH);
 		isCloud.setLayoutData(gd);
 		isCloud.setSelection(false);
+		isCloud.setVisible(false);
+		
 		isCloud.addSelectionListener(new SelectionListener() {
 
 			@Override


### PR DESCRIPTION
Since after click on this checkbox unable to login with the correct credentials.
The simple solution to solve this issue is hiding the checkbox.