### PR TITLE
Fix TOOLS-3460 - Enable ReDeploy option for CAPP

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver.base/src/org/wso2/developerstudio/eclipse/carbonserver/base/manager/CarbonServerManager.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver.base/src/org/wso2/developerstudio/eclipse/carbonserver/base/manager/CarbonServerManager.java
@@ -394,7 +394,7 @@ public final class CarbonServerManager implements IServerManager {
 		}
 	}
 
-	private static void addExistingServers() {
+	public static void addExistingServers() {
 		IServer[] s = ServerCore.getServers();
 		for (IServer server : s) {
 			if (!getServers().contains(server))

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44/src/org/wso2/developerstudio/eclipse/carbonserver44/operations/ServiceModuleOperations.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44/src/org/wso2/developerstudio/eclipse/carbonserver44/operations/ServiceModuleOperations.java
@@ -100,7 +100,11 @@ public class ServiceModuleOperations {
 	}
 
 	public void redeployModule(boolean force) {
-		CarbonServerInformation wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
+		CarbonServerInformation wsasServerInformation = null;
+		if(CarbonServerManager.getAppServerInformation().isEmpty()){
+	        CarbonServerManager.addExistingServers();
+		}
+	    wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
 		if (!force && !wsasServerInformation.getChangedProjects().contains(project)) {
 			return;
 		}


### PR DESCRIPTION
This fixes the issue of disappearing the Redeploy option for CAPP when restarting eclipse
Public Jira - https://wso2.org/jira/browse/TOOLS-3460