### PR TITLE
Add correct version to EI server plugin

### DIFF
--- a/features/org.wso2.developerstudio.carbon.server-44ei.feature/feature.xml
+++ b/features/org.wso2.developerstudio.carbon.server-44ei.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.wso2.developerstudio.carbon.server-44ei.feature"
       label="WSO2 Enterprise Integrator (Carbon 4.4 based) Feature"
-      version="4.1.1.qualifier"
+      version="4.2.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://wso2.com">

--- a/features/org.wso2.developerstudio.carbon.server-44ei.feature/pom.xml
+++ b/features/org.wso2.developerstudio.carbon.server-44ei.feature/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>wso2-developerstudio-kernel-features</artifactId>
         <groupId>org.wso2.developerstudio</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.developerstudio.carbon.server-44ei.feature</artifactId>

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/META-INF/MANIFEST.MF
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Carbonserver44ei
 Bundle-SymbolicName: org.wso2.developerstudio.eclipse.carbonserver44ei;singleton:=true
-Bundle-Version: 4.1.1.qualifier
+Bundle-Version: 4.2.0.qualifier
 Bundle-Activator: org.wso2.developerstudio.eclipse.carbonserver44ei.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -53,4 +53,4 @@ Import-Package: javax.xml.stream;version="1.0.1.wso2v1",
  org.wso2.developerstudio.eclipse.utils.file;version="[4.1.0,5.0.0)",
  org.wso2.developerstudio.eclipse.utils.wst;version="[4.1.0,5.0.0)"
 Bundle-Vendor: WSO2
-Export-Package: org.wso2.developerstudio.eclipse.carbonserver44ei.register.product.servers;version="4.1.0"
+Export-Package: org.wso2.developerstudio.eclipse.carbonserver44ei.register.product.servers;version="4.2.0"

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/pom.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wso2-developerstudio-kernel-plugins</artifactId>
         <groupId>org.wso2.developerstudio</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>  
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This fixes the issue of using incorrect version in org.wso2.developerstudio.eclipse.carbonserver44ei feature/plugin