### PR TITLE
Enable ReDeploy option for CAPP

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/src/org/wso2/developerstudio/eclipse/carbonserver44ei/operations/ServiceModuleOperations.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/src/org/wso2/developerstudio/eclipse/carbonserver44ei/operations/ServiceModuleOperations.java
@@ -100,7 +100,12 @@ public class ServiceModuleOperations {
 	}
 
 	public void redeployModule(boolean force) {
-		CarbonServerInformation wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
+		//Fixing TOOLS-3460
+		CarbonServerInformation wsasServerInformation = null;
+		if(CarbonServerManager.getAppServerInformation().isEmpty()){
+	        CarbonServerManager.addExistingServers();
+		}
+	    wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
 		if (!force && !wsasServerInformation.getChangedProjects().contains(project)) {
 			return;
 		}

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/src/org/wso2/developerstudio/eclipse/carbonserver44ei/operations/ServiceModuleOperations.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44ei/src/org/wso2/developerstudio/eclipse/carbonserver44ei/operations/ServiceModuleOperations.java
@@ -100,12 +100,12 @@ public class ServiceModuleOperations {
 	}
 
 	public void redeployModule(boolean force) {
-		//Fixing TOOLS-3460
+		// Fixing TOOLS-3460
 		CarbonServerInformation wsasServerInformation = null;
-		if(CarbonServerManager.getAppServerInformation().isEmpty()){
-	        CarbonServerManager.addExistingServers();
+		if (CarbonServerManager.getAppServerInformation().isEmpty()) {
+			CarbonServerManager.addExistingServers();
 		}
-	    wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
+		wsasServerInformation = CarbonServerManager.getAppServerInformation().get(server);
 		if (!force && !wsasServerInformation.getChangedProjects().contains(project)) {
 			return;
 		}


### PR DESCRIPTION
This fixes the issue of disappearing the Redeploy option for CAPP when restarting eclipse
(fix is for EI server)
Public Jira - https://wso2.org/jira/browse/TOOLS-3460