### PR TITLE
Remove 'ComplexEventProcessor' and 'GovernanceRegistry' server roles

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.distribution.project/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.distribution.project/plugin.xml
@@ -261,10 +261,7 @@
 		 <register.serverRole
        artifactType="service/dataservice"
        serverRole="DataServicesServer"/>
- 		<register.serverRole
-       artifactType="cep/bucket"
-       serverRole="ComplexEventProcessor"/>
- 		<register.serverRole
+ 		 <register.serverRole
        artifactType="synapse/sequence"
        serverRole="EnterpriseServiceBus"/>
  		<register.serverRole
@@ -278,7 +275,7 @@
        serverRole="EnterpriseServiceBus"/>
  		<register.serverRole
        artifactType="registry/resource"
-       serverRole="GovernanceRegistry"/>
+       serverRole="EnterpriseServiceBus"/>
 		 <register.serverRole
        artifactType="bpel/workflow"
        serverRole="BusinessProcessServer"/>
@@ -288,12 +285,6 @@
 		 <register.serverRole
        artifactType="lib/dataservice/validator"
        serverRole="DataServicesServer"/>
-		 <register.serverRole
-       artifactType="lib/registry/handlers"
-       serverRole="GovernanceRegistry"/>
-		 <register.serverRole
-       artifactType="lib/registry/filter"
-       serverRole="GovernanceRegistry"/>
 		 <register.serverRole
        artifactType="synapse/local-entry"
        serverRole="EnterpriseServiceBus"/>

--- a/plugins/org.wso2.developerstudio.eclipse.distribution.project/src/org/wso2/developerstudio/eclipse/distribution/project/ui/wizard/DistributionProjectExportWizardPage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.distribution.project/src/org/wso2/developerstudio/eclipse/distribution/project/ui/wizard/DistributionProjectExportWizardPage.java
@@ -58,9 +58,8 @@ public class DistributionProjectExportWizardPage extends WizardPage {
 	private boolean pageDirty = false;
 	private boolean controlCreated = false;
 	// need to get the server roles via an extension point without hard-coding
-	private final String[] serverRoles = new String[] { "GovernanceRegistry", 
-	                "BusinessProcessServer", "EnterpriseServiceBus", 
-	                "ComplexEventProcessor", "DataServicesServer", 
+	private final String[] serverRoles = new String[] { "BusinessProcessServer",
+	                "EnterpriseServiceBus", "DataServicesServer",
 	                "EnterpriseIntegrator" };
 
 	public Map<String, Dependency> getDependencyList() {


### PR DESCRIPTION
Removed 'ComplexEventProcessor' and 'GovernanceRegistry' server roles from CAPP pom editor and composite application project export wizard since they are not supported by EI tooling. 
Related Issue : https://github.com/wso2/devstudio-tooling-ei/issues/65