### PR TITLE
Fix product-ei#1428

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.registry/src/org/wso2/developerstudio/eclipse/artifact/registry/ui/wizard/RegistryResourceCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.registry/src/org/wso2/developerstudio/eclipse/artifact/registry/ui/wizard/RegistryResourceCreationWizard.java
@@ -184,7 +184,7 @@ public class RegistryResourceCreationWizard extends AbstractWSO2ProjectCreationW
 			artifact.setName(regModel.getArtifactName());
 			artifact.setVersion(version);
 			artifact.setType("registry/resource");
-			artifact.setServerRole("GovernanceRegistry");
+			artifact.setServerRole("EnterpriseIntegrator");
 			artifact.setGroupId(groupId);
 			List<RegistryResourceInfo> registryResources = regResInfoDoc.getRegistryResources();
 			for (RegistryResourceInfo registryResourceInfo : registryResources) {


### PR DESCRIPTION
Replace registry project server role to "EnterpriseIntegrator" to enable deploying CApps that have only registry resources. 

## Purpose
Fixed: https://github.com/wso2/product-ei/issues/1428

## Goals
Without the fix "GovernanceRegistry" server role has throwing "Has no artifacts" error when a CApp only with registry resources was deployed, because that server role is not defined in WSO2 EI carbon.xml. Changed to the default "EnterpriseIntegrator" server role at EI.
