### PR TITLE
Add datamapper test window functionality.

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/META-INF/MANIFEST.MF
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/META-INF/MANIFEST.MF
@@ -36,10 +36,6 @@ Import-Package: javax.servlet;version="3.1.0",
  org.wso2.developerstudio.eclipse.samples.contributor;version="[6.0.0,7.0.0)",
  org.wso2.developerstudio.eclipse.samples.utils;version="[6.0.0,7.0.0)",
  org.wso2.developerstudio.eclipse.samples.wizards;version="[6.0.0,7.0.0)"
-Export-Package: org.wso2.developerstudio.eclipse.templates.dashboard.handlers;version="6.5.0";
-  uses:="org.eclipse.core.runtime,
-   org.eclipse.swt.graphics,
-   org.eclipse.jface.resource,
-   org.eclipse.ui.forms.editor,
-   org.eclipse.ui.forms",
- org.wso2.developerstudio.eclipse.templates.dashboard.help
+Export-Package: org.wso2.developerstudio.eclipse.templates.dashboard.handlers;version="6.5.0",
+ org.wso2.developerstudio.eclipse.templates.dashboard.help;version="6.5.0",
+ org.wso2.developerstudio.eclipse.templates.dashboard.web.function.server;version="6.5.0"

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/pom.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/pom.xml
@@ -27,12 +27,12 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.3.v20170317</version>
+			<version>9.4.14.v20181114</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>9.4.3.v20170317</version>
+			<version>9.4.14.v20181114</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/JettyServerHandler.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/JettyServerHandler.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -39,6 +40,11 @@ public class JettyServerHandler {
     private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
     private static JettyServerHandler jettyServerHandler;
     public static boolean serverStarted;
+    private static HandlerCollection contexts;
+
+    public HandlerCollection getHandlerCollection() {
+        return contexts;
+    }
 
     private JettyServerHandler() {
         super();
@@ -47,7 +53,11 @@ public class JettyServerHandler {
     public static JettyServerHandler getInstance() {
         if (jettyServerHandler == null) {
             jettyServerHandler = new JettyServerHandler();
+            // Once the server started handler collection becomes immutable.
+            // We are using "true" here to keep it mutable
+            contexts = new HandlerCollection(true);
         }
+        
         return jettyServerHandler;
     }
 
@@ -122,9 +132,9 @@ public class JettyServerHandler {
         // Context path where servlets are hosted
         ServletContextHandler wsContext = new ServletContextHandler();
         wsContext.setContextPath("/servlet");
-
-        ContextHandlerCollection contexts = new ContextHandlerCollection();
-        contexts.setHandlers(new Handler[] { context, wsContext });
+        
+        contexts.addHandler(wsContext);
+        contexts.addHandler(context);
 
         server.setHandler(contexts);
         // All the static web page requests are handled through DefaultServlet


### PR DESCRIPTION
## Purpose
> Introduce a test window for Data-mapper mediator.

## Goals
> Once the mapping is done and saved, users can test the output without deploying the
artefacts to the ESB.

## Approach
> Introduce an HTML view to do the testing. Call the mediate method of Data mapper mediator to receive identical results as in WSO2 ESB