### PR TITLE
Removing localhost references from getting started page

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/TemplateDash/js/app_new.js
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/TemplateDash/js/app_new.js
@@ -168,13 +168,13 @@ $('#show-welcome').change(function() {
 });
 
 function openWizard(wizardid) {
-    $.post("http://localhost:"+portValue+"/servlet/openide", { status: wizardid } ,function(data, status){
+    $.post("http://127.0.0.1:"+portValue+"/servlet/openide", { status: wizardid } ,function(data, status){
     });
 }
 
 function GetDashboardWizards() {
 	var jsonString;
-    $.get("http://localhost:"+portValue+"/servlet/getwizards", function(data, status){
+    $.get("http://127.0.0.1:"+portValue+"/servlet/getwizards", function(data, status){
         loadWelcomeNodes(JSON.stringify(data));
     });
 }
@@ -273,12 +273,12 @@ function searchTemplates(searchInput, templateList){
 
 function updateWelcomeDisplayConfiguration() {
 	var checkBox = document.getElementById("show-welcome");
-	$.post("http://localhost:" + portValue + "/servlet/savewelcomeconfig", { status: checkBox.checked } ,function(data, status){
+	$.post("http://127.0.0.1:" + portValue + "/servlet/savewelcomeconfig", { status: checkBox.checked } ,function(data, status){
     });
 }
 
 function loadDisableWelcomePageParameter() {
-	 $.get("http://localhost:" + portValue + "/servlet/getwelcomeconfig", function(data, status) {
+	 $.get("http://127.0.0.1:" + portValue + "/servlet/getwelcomeconfig", function(data, status) {
 		 var checkBox = document.getElementById("show-welcome");   
 		 var data = JSON.stringify(data);
 		 var disableWelcome = JSON.parse(data);

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
@@ -85,7 +85,7 @@ public class WelcomePageEditor extends EditorPart {
 	public void createPartControl(Composite parent) {
 	    browser = createBrowser(parent);
 	    String port = getPortValueForJS();
-	    browser.setUrl("http://localhost:" + port + "/welcome?port=" + port);
+	    browser.setUrl("http://127.0.0.1:" + port + "/welcome?port=" + port);
 	     
 	    IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 	    try {


### PR DESCRIPTION
## Purpose
There is a possibility of 'localhost' hostname to be mapped to some other ips in client machine. Further when we use a hostname, resolution depends on the DNS mechanisms also. Hence removing localhost references from getting started page and using direct loopback address. 

