### PR TITLE
Fix: Pass project nature before project creation.

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.distribution.project/src/org/wso2/developerstudio/eclipse/distribution/project/ui/wizard/DistributionProjectWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.distribution.project/src/org/wso2/developerstudio/eclipse/distribution/project/ui/wizard/DistributionProjectWizard.java
@@ -67,6 +67,7 @@ public class DistributionProjectWizard extends
 	public boolean performFinish() {
 		try {
 			DistributionProjectModel projectModel = (DistributionProjectModel) getModel();
+			setProjectNature(DISTRIBUTION_PROJECT_NATURE);
 			project = createNewProject();
 			File pomfile = project.getFile("pom.xml").getLocation().toFile();
 			createPOM(pomfile);

--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/ui/wizard/ContainerProjectCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/ui/wizard/ContainerProjectCreationWizard.java
@@ -278,6 +278,13 @@ public class ContainerProjectCreationWizard extends AbstractWSO2ProjectCreationW
                 this.getModel().setLocation(projectLocation);
                 this.getModel().setIsUserDefine(false);
             }
+            
+            // Passing the project nature for creation.
+            if (dockerModel.isKubernetesExporterProjectChecked()) {
+                setProjectNature(Constants.KUBERNETES_EXPORTER_PROJECT_NATURE);
+            } else if (dockerModel.isDockerExporterProjectChecked()) {
+                setProjectNature(Constants.DOCKER_EXPORTER_PROJECT_NATURE);
+            }
             project = createNewProject();
 
             // Creating CarbonApps and Libs and CarbonHome folders

--- a/plugins/org.wso2.developerstudio.eclipse.general.project/src/org/wso2/developerstudio/eclipse/general/project/ui/wizard/GeneralProjectWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.general.project/src/org/wso2/developerstudio/eclipse/general/project/ui/wizard/GeneralProjectWizard.java
@@ -53,6 +53,7 @@ public class GeneralProjectWizard extends AbstractWSO2ProjectCreationWizard {
 	
 	public boolean performFinish() {
 		try {
+			setProjectNature(GENERAL_PROJECT_NATURE);
 			project = createNewProject();
 			JavaUtils.addJavaNature(project,false);
 			


### PR DESCRIPTION
## Purpose
Set project nature of the following projects:

1. Composite Application project
2. Docker Exported Project
3. Kubernetes Exporter project

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1046