### PR TITLE
CompositeApplication Creation wizard appears even if the Integration project has a Composite Application project

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/launch/MicroIntegratorRunLaunchDelegate.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/launch/MicroIntegratorRunLaunchDelegate.java
@@ -99,6 +99,12 @@ public class MicroIntegratorRunLaunchDelegate implements ILaunchConfigurationDel
         IResource selectedCARAppResource = selectedProject.getParent()
                 .findMember(currentProjectName + "CompositeApplication");
         
+        //check selected project is created from new Integration Wizard
+        if (selectedCARAppResource == null) {
+            selectedCARAppResource = selectedProject.getParent()
+                    .findMember(currentProjectName.split("ConfigProject")[0] + "CompositeApplication");
+        }
+        
         boolean isCompositeSelectionPageNeeded = false;
         if (selectedCARAppResource == null && currentProjectName != null
                 && !currentProjectName.contains("CompositeApplication")


### PR DESCRIPTION
#Purpose
> Related issue - https://github.com/wso2/devstudio-tooling-ei/issues/1043