### PR TITLE
Fix: welcome page become blank issue

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
@@ -41,6 +41,7 @@ import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
 import org.wso2.developerstudio.eclipse.logging.core.Logger;
 import org.wso2.developerstudio.eclipse.templates.dashboard.Activator;
 import org.wso2.developerstudio.eclipse.templates.dashboard.web.function.server.FunctionServerConstants;
+import org.wso2.developerstudio.eclipse.webui.core.exception.WebUIException;
 
 
 public class WelcomePageEditor extends EditorPart {
@@ -84,13 +85,11 @@ public class WelcomePageEditor extends EditorPart {
 	@Override
 	public void createPartControl(Composite parent) {
 	    browser = createBrowser(parent);
-	    String port = getPortValueForJS();
-	    browser.setUrl("http://127.0.0.1:" + port + "/welcome?port=" + port);
-	     
-	    IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 	    try {
+	        browser.setUrl(getWelcomePageURL());
+	        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 	        PlatformUI.getWorkbench().showPerspective("WELCOME_PERSPECTIVE", window);
-	    } catch (WorkbenchException e) {
+	    } catch (WorkbenchException | WebUIException e) {
 	        log.error("Could not load the perspective.", e);
 	    }
 	}
@@ -127,6 +126,27 @@ public class WelcomePageEditor extends EditorPart {
     private String getPortValueForJS() {
         IEclipsePreferences rootNode = Platform.getPreferencesService().getRootNode();
         return rootNode.get("portDetails", String.valueOf(FunctionServerConstants.EMBEDDED_SERVER_PORT));
+    }
+    
+    /**
+     * Returns the path of the welcome page.
+     * 
+     * @return path
+     * @throws WebUIException errors while retrieving path
+     */
+    public String getWelcomePageURL() throws WebUIException {
+        URL webAppURL = Activator.getDefault().getBundle().getEntry(WELCOME_PAGE_WEB_SITE_FOLDER);
+        File resolvedWebAppFolder;
+        File resolvedWebAppIndex;
+        try {
+            URL resolvedFolderURL = FileLocator.toFileURL(webAppURL);
+            URI resolvedFolderURI = new URI(resolvedFolderURL.getProtocol(), resolvedFolderURL.getPath(), null);
+            resolvedWebAppFolder = new File(resolvedFolderURI);
+            resolvedWebAppIndex = new File(resolvedWebAppFolder, INDEX_HTML);
+            return resolvedWebAppIndex.getAbsolutePath() + "?port=" + getPortValueForJS();
+        } catch (IOException | URISyntaxException e) {
+            throw new WebUIException("Error while resolving the file path of web app.", e);
+        }
     }
 
 	@Override


### PR DESCRIPTION
Instead of setting the webURL to the browser, set physical path of the file.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1080