### PR TITLE
Open MI Monitoring dashboard with existing apps

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/monitoring/dashboard/MonitoringDashboard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/monitoring/dashboard/MonitoringDashboard.java
@@ -83,7 +83,7 @@ public class MonitoringDashboard {
 
                     // check port availability
                     while (!MonitoringDashboardUtil.checkPortAvailability(serverHost, serverPort)) {
-                        throw new IOException("Port " + serverPort + " is not available.");
+                        return;
                     }
 
                     // Starting the dashboard


### PR DESCRIPTION
If there is a running MI Monitoring Dashboard app in the background (on the port 9390), open the dashboard in the browser pointing to that Dashboard app.