### PR TITLE
Set text editor for properties and jks files

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/ui/wizard/DockerNavigatorActionProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/ui/wizard/DockerNavigatorActionProvider.java
@@ -97,6 +97,10 @@ public class DockerNavigatorActionProvider extends CommonActionProvider {
                     } else if (fileTobeOpen.getFileExtension().equals("html")) {
                         page.openEditor(new FileEditorInput(fileTobeOpen),
                                 DockerProjectConstants.INTERNAL_BROWSER_EDITOR_ID);
+                    } else if (fileTobeOpen.getFileExtension().equals("properties")
+                            || fileTobeOpen.getFileExtension().equals("jks")) {
+                        page.openEditor(new FileEditorInput(fileTobeOpen),
+                                DockerProjectConstants.DEFAULT_TEXT_EDITOR_ID);
                     } else {
                         page.openEditor(new FileEditorInput(fileTobeOpen), DockerProjectConstants.DOCKER_EDITOR);
                     }

--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/utils/DockerProjectConstants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/utils/DockerProjectConstants.java
@@ -108,6 +108,7 @@ public class DockerProjectConstants extends NLS {
     public static final String DOCKER_FILE_AUTO_GENERATION_BEGIN = "#[DO NOT REMOVE] Auto generated Docker commands for config-map parser";
     public static final String DOCKER_FILE_AUTO_GENERATION_END = "#[DO NOT REMOVE] End of auto generated Docker commands for config-map parser";
     public static final String INTERNAL_BROWSER_EDITOR_ID = "org.eclipse.ui.browser.editor";
+    public static final String DEFAULT_TEXT_EDITOR_ID = "org.eclipse.ui.DefaultTextEditor";
     
     public static String KUBERNETES_PROJECT_TYPE;
     public static String DOCKER_PROJECT_TYPE;


### PR DESCRIPTION
## Purpose
Set default text editor for properties and jks files inside docker project.
Fix https://github.com/wso2/devstudio-tooling-ei/issues/1055