### PR TITLE
Fix MI Monitoring dashboard not opening windows

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/monitoring/dashboard/MonitoringDashboard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/monitoring/dashboard/MonitoringDashboard.java
@@ -88,11 +88,10 @@ public class MonitoringDashboard {
 
                     // Starting the dashboard
                     String miMonitoringDashboardPath = MonitoringDashboardUtil.getMIMonitoringDashboardPath();
-                    String javaHomeEnvVar = MonitoringDashboardConstants.JAVA_HOME_ENV_VAR +
-                            "=" + MonitoringDashboardUtil.getJavaHomePath();
-                    String[] cmd = { miMonitoringDashboardPath };
-                    String[] env = { javaHomeEnvVar };
-                    Process processor = Runtime.getRuntime().exec(cmd, env);
+                    ProcessBuilder processBuilder = new ProcessBuilder(miMonitoringDashboardPath);
+                    processBuilder.environment().put(MonitoringDashboardConstants.JAVA_HOME_ENV_VAR,
+                            MonitoringDashboardUtil.getJavaHomePath());
+                    Process processor = processBuilder.start();
 
                     BufferedReader inputBuffer = new BufferedReader(new InputStreamReader(processor.getInputStream()));
                     String line = null;


### PR DESCRIPTION
## Purpose
Starting the process using a process builder so that the following code block in `mi-monitoring-dashboard\wso2\server\bin\carbon.bat` gets executed without an issue.

<pre>
:checkJdk16  
"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
IF ERRORLEVEL 1 goto unknownJdk
goto jdk16
</pre>

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1198