### PR TITLE
Rename project wizard extension

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.distribution.project/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.distribution.project/plugin.xml
@@ -7,7 +7,7 @@
    <extension-point id="org.wso2.developerstudio.eclipse.capp.artifacts.provider" name="org.wso2.developerstudio.eclipse.capp.artifacts.provider" schema="schema/org.wso2.developerstudio.eclipse.capp.artifacts.provider.exsd"/>
    <extension-point id="org.wso2.developerstudio.eclipse.docker.artifacts.provider" name="org.wso2.developerstudio.eclipse.docker.artifacts.provider" schema="schema/org.wso2.developerstudio.eclipse.docker.artifacts.provider.exsd"/>
 	<extension point="org.eclipse.ui.newWizards">
-		<wizard name="Composite Application Project" 
+		<wizard name="Composite Exporter" 
 			category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.capp.distribution"
 			class="org.wso2.developerstudio.eclipse.distribution.project.ui.wizard.DistributionProjectWizard"
             finalPerspective="org.eclipse.jst.j2ee.J2EEPerspective"
@@ -15,7 +15,7 @@
 			wizardManifest="project_wizard.xml"
 			icon="icons/distribution-project-12.png"
 			project="true">
-			<description>Composite Application Project</description>
+			<description>Composite Exporter</description>
 		</wizard>
    </extension>
    <extension point="org.eclipse.ui.newWizards">

--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/plugin.xml
@@ -7,9 +7,9 @@
                class="org.wso2.developerstudio.eclipse.docker.distribution.ui.wizard.DockerProjectCreationWizard"
                icon="icons/docker-16.png"
                id="org.wso2.developerstudio.eclipse.artifact.newdockerproject"
-               name="Docker Exporter Project"
+               name="Docker Exporter"
                project="true">
-            <description>Docker Project</description>
+            <description>Docker Exporter</description>
         </wizard>
     </extension>
     <extension point="org.eclipse.ui.newWizards">
@@ -18,9 +18,9 @@
                class="org.wso2.developerstudio.eclipse.docker.distribution.ui.wizard.KubernetesProjectCreationWizard"
                icon="icons/k8s-16.png"
                id="org.wso2.developerstudio.eclipse.artifact.newkubernetesproject"
-               name="Kubernetes Exporter Project"
+               name="Kubernetes Exporter"
                project="true">
-            <description>Kubernetes Project</description>
+            <description>Kubernetes Exporter</description>
         </wizard>
     </extension>
  

--- a/plugins/org.wso2.developerstudio.eclipse.general.project/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.general.project/plugin.xml
@@ -2,7 +2,7 @@
 <?eclipse version="3.4"?>
 <plugin>
 	<extension point="org.eclipse.ui.newWizards">
-		<wizard name="Registry Resources Project" 
+		<wizard name="Registry Resources" 
 			category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.repository"
 			class="org.wso2.developerstudio.eclipse.general.project.ui.wizard.GeneralProjectWizard"
             finalPerspective="org.eclipse.jst.j2ee.J2EEPerspective"
@@ -10,7 +10,7 @@
 			wizardManifest="project_wizard.xml"
 			icon="icons/general-project-12.png"
 			project="true">
-			<description>Registry Resources Project</description>
+			<description>Registry Resources</description>
 		</wizard>
    </extension>
    <extension point="org.wso2.developerstudio.eclipse.dashboad.link">


### PR DESCRIPTION
Rename project wizard extension for composite, docker, k8 and registry project modules.

Fix https://github.com/wso2/devstudio-tooling-ei/issues/1212