### PR TITLE
Refine to support previous IS versions

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/serverdefinition/carbon.microIntegrator.definition.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/serverdefinition/carbon.microIntegrator.definition.xml
@@ -122,7 +122,7 @@
             -Djava.net.preferIPv4Stack=true -DNonRegistryMode=true -DNonUserCoreMode=true -Dcom.ibm.cacheLocalHost=true
             -Dcarbon.use.registry.repo=false -DworkerNode=false
             -Dorg.apache.cxf.io.CachedOutputStream.Threshold=104857600 -Dprofile=micro-integrator-default
-            -Desb.debug=${esb.debug} -DenableManagementApi=true -DenableReadinessProbe=true -DgracefulShutdown=false
+            -Desb.debug=${esb.debug} -DenableManagementApi=true -DenablePrometheusApi=true -DgracefulShutdown=false
         </vmParameters>
         <programArguments></programArguments>
         <classpathReference>carbon.libs</classpathReference>

--- a/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/internal/CarbonServerBehavior44microei12.java
+++ b/plugins/org.wso2.developerstudio.eclipse.carbonserver44microei12/src/org/wso2/developerstudio/eclipse/carbonserver44microei12/internal/CarbonServerBehavior44microei12.java
@@ -127,14 +127,14 @@ public class CarbonServerBehavior44microei12 extends CarbonServerBehaviour {
             }
 
             List<String> urls = new ArrayList<String>();
-            int port = 9191; // default ReadinessProbe API port
+            int port = 9191; // default Prometheus API port
             int offSet = Integer.valueOf(offsetString);
 
             String newUrl = url;
             newUrl = newUrl + ":" + (port + offSet);
 
-            // ReadinessProbe API is used as the ping server
-            newUrl = newUrl + "/healthz";
+            // Prometheus API is used as the ping server
+            newUrl = newUrl + "/metric-service/metrics";
             urls.add(newUrl);
 
             return urls.toArray(new String[] {});

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/WelcomeDashboard/libs/app_new.js
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/WelcomeDashboard/libs/app_new.js
@@ -100,10 +100,10 @@ var sampleMediatorList = {
 	    "periodical scheduled tasks": "scheduled-task,sequence,call,log,address-endpoint",
 	    "database polling": "scheduled-task,sequence,dataservice,address-endpoint,log,header,payload-factory,call",
 	    "proxying a rest service": "api,log,call,http-endpoint,respond",
-	    "hello docker": "docker",
-	    "hello kubernetes": "kubernetes",
-	    "unit test tutorial": "test",
-	    "api testing": "test",
+	    "hello docker": "docker,api,payload-factory,respond",
+	    "hello kubernetes": "kubernetes,k8,api,payload-factory,respond",
+	    "unit test tutorial": "testing,unit,api,sequence,switch,payload-factory,respond,log,drop",
+	    "api testing": "test,api,property,payload-factory,respond,unit",
 	    "email service": "email,connector,api,respond,foreach,payload-factory,property,log"
 };
 

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/PlatformEarlyStartUpHandler.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/PlatformEarlyStartUpHandler.java
@@ -17,6 +17,7 @@
 package org.wso2.developerstudio.eclipse.templates.dashboard.handlers;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,10 +123,13 @@ public class PlatformEarlyStartUpHandler implements IStartup {
     private void setDefaultMavenInstallation() {
         final MavenRuntimeManagerImpl runtimeManager = MavenPluginActivator.getDefault().getMavenRuntimeManager();
         List<AbstractMavenRuntime> runtimes = runtimeManager.getMavenRuntimes(false);
-        AbstractMavenRuntime newRuntime = new MavenExternalRuntime("IntegrationStudioEmbedded", getMavenHomePath());
-        runtimes.add(newRuntime);
-        runtimeManager.setRuntimes(runtimes);
-        runtimeManager.setDefaultRuntime(newRuntime);
+        String mavenHomePath = getMavenHomePath();
+        if (Files.exists(Paths.get(mavenHomePath))) {
+            AbstractMavenRuntime newRuntime = new MavenExternalRuntime("IntegrationStudioEmbedded", mavenHomePath);
+            runtimes.add(newRuntime);
+            runtimeManager.setRuntimes(runtimes);
+            runtimeManager.setDefaultRuntime(newRuntime);
+        }
     }
     
     /**


### PR DESCRIPTION
Set prometheus API as embedded server checkup and fix embedded maven setting issue with prevous versions of Integration Studio.