### PR TITLE
Add no cache to urls

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/resources/DockerUserGuideTemplate.java
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/resources/DockerUserGuideTemplate.java
@@ -37,6 +37,7 @@ public class DockerUserGuideTemplate extends ViewPart {
     private Browser browser;
     public static final String TEMPLATE_GUIDE_VIEW_ID = "org.wso2.developerstudio.eclipse.esb.templates.docker.view";
     public static final String ERROR_MESSAGE_OPENING_EDITOR = "Error opening editor";
+    private static final String NO_CACHE = "?nocache=1";
 
     @Override
     public void createPartControl(Composite arg0) {
@@ -58,7 +59,7 @@ public class DockerUserGuideTemplate extends ViewPart {
         URL resolvedFolderURL = FileLocator.toFileURL(webAppURL);
         URI resolvedFolderURI = new URI(resolvedFolderURL.getProtocol(), resolvedFolderURL.getPath(), null);
         File resolvedWebAppFile = new File(resolvedFolderURI);
-        return resolvedWebAppFile.getAbsolutePath();
+        return resolvedWebAppFile.getAbsolutePath() + NO_CACHE;
     }
 
     @Override
@@ -66,6 +67,6 @@ public class DockerUserGuideTemplate extends ViewPart {
     }
 
     public void setURL(URL url) {
-        browser.setUrl(url.toString());
+        browser.setUrl(url.toString() + NO_CACHE);
     }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/resources/K8sUserGuideTemplate.java
+++ b/plugins/org.wso2.developerstudio.eclipse.docker.distribution/src/org/wso2/developerstudio/eclipse/docker/distribution/resources/K8sUserGuideTemplate.java
@@ -37,6 +37,7 @@ public class K8sUserGuideTemplate extends ViewPart {
     private Browser browser;
     public static final String TEMPLATE_GUIDE_VIEW_ID = "org.wso2.developerstudio.eclipse.esb.templates.kubernetes.view";
     public static final String ERROR_MESSAGE_OPENING_EDITOR = "Error opening editor";
+    private static final String NO_CACHE = "?nocache=1";
 
     @Override
     public void createPartControl(Composite arg0) {
@@ -58,7 +59,7 @@ public class K8sUserGuideTemplate extends ViewPart {
         URL resolvedFolderURL = FileLocator.toFileURL(webAppURL);
         URI resolvedFolderURI = new URI(resolvedFolderURL.getProtocol(), resolvedFolderURL.getPath(), null);
         File resolvedWebAppFile = new File(resolvedFolderURI);
-        return resolvedWebAppFile.getAbsolutePath();
+        return resolvedWebAppFile.getAbsolutePath() + NO_CACHE;
     }
 
     @Override
@@ -66,6 +67,6 @@ public class K8sUserGuideTemplate extends ViewPart {
     }
 
     public void setURL(URL url) {
-        browser.setUrl(url.toString());
+        browser.setUrl(url.toString() + NO_CACHE);
     }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/JettyServerHandler.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/handlers/JettyServerHandler.java
@@ -121,7 +121,7 @@ public class JettyServerHandler {
         //context.addFilter(holder, "*", null);
         // Context path where static webpages are hosted
         context.setContextPath("/welcome");
-        String webAppPath = "TemplateDash";
+        String webAppPath = "WelcomeDashboard";
         try {
             // Get web app path from current bundle
             webAppPath = jsf.getWebAppPath();

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/help/TemplateGuideView.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/help/TemplateGuideView.java
@@ -33,6 +33,7 @@ import java.net.URL;
 
 public class TemplateGuideView extends ViewPart {
 
+	private static final String NO_CACHE = "?nocache=1";
     private Browser browser;
 
     @Override
@@ -58,7 +59,7 @@ public class TemplateGuideView extends ViewPart {
         URI resolvedFolderURI = new URI(resolvedFolderURL.getProtocol(), resolvedFolderURL.getPath(), null);
         File resolvedWebAppFolder = new File(resolvedFolderURI);
         File resolvedWebAppIndex = new File(resolvedWebAppFolder, INDEX_HTML);
-        return resolvedWebAppIndex.getAbsolutePath();
+        return resolvedWebAppIndex.getAbsolutePath() + NO_CACHE;
     }
 
     @Override
@@ -67,7 +68,7 @@ public class TemplateGuideView extends ViewPart {
     }
 
     public void setURL(URL url) {
-        browser.setUrl(url.toString());
+        browser.setUrl(url.toString() + NO_CACHE);
     }
 
 }

--- a/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
+++ b/plugins/org.wso2.developerstudio.eclipse.templates.dashboard/src/org/wso2/developerstudio/eclipse/templates/dashboard/web/view/WelcomePageEditor.java
@@ -85,7 +85,7 @@ public class WelcomePageEditor extends EditorPart {
 	public void createPartControl(Composite parent) {
 	    browser = createBrowser(parent);
 	    String port = getPortValueForJS();
-	    browser.setUrl("http://127.0.0.1:" + port + "/welcome?port=" + port);
+	    browser.setUrl("http://127.0.0.1:" + port + "/welcome?port=" + port + "&nocache=1");
 	     
 	    IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 	    try {


### PR DESCRIPTION
## Purpose
Add `nocache=1` to urls to avoid loading views from previous versions of developer studio when old workspace are used.

##Affected views
1. Docker and Kubernetes guides
2. Getting Started Page
3. Sample Guide

Fix: https://github.com/wso2/devstudio-tooling-ei/issues/1234